### PR TITLE
IBX-1993: Fixed PHP8 deprecation warning coming from upstream `webonyx/graphql-php`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name":              "webonyx/graphql-php",
+  "name":              "ibexa/graphql-php",
   "description":       "A PHP port of GraphQL reference implementation",
   "type":              "library",
   "license":           "MIT",
@@ -8,8 +8,11 @@
     "graphql",
     "API"
   ],
+  "replace": {
+    "webonyx/graphql-php": "self.version"
+  },
   "require": {
-    "php": "^7.1||^8.0",
+    "php": "^7.3 || ^8.0",
     "ext-json": "*",
     "ext-mbstring": "*"
   },

--- a/src/Error/FormattedError.php
+++ b/src/Error/FormattedError.php
@@ -301,7 +301,7 @@ class FormattedError
      *
      * @return callable|callable
      */
-    public static function prepareFormatter(?callable $formatter = null, $debug)
+    public static function prepareFormatter(?callable $formatter, $debug)
     {
         $formatter = $formatter ?: static function ($e) {
             return FormattedError::createFromException($e);


### PR DESCRIPTION
https://issues.ibexa.co/browse/IBX-1993

Setting up a fork to fix a PHP8 deprecation warning, ref: https://github.com/webonyx/graphql-php/pull/743.